### PR TITLE
dataurls start at any index

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function(options) {
   function prependUrls(css) {
     return rework(css)
       .use(reworkUrl(function(url) {
-        if (url.indexOf('data:') === 0) {
+        if (~url.indexOf('data:')) {
           return url;
         } else {
           var newUrl = url;


### PR DESCRIPTION
E.g.:
`url(data:image/svg+xml,<svg viewbox="0 0 100 100">...</svg>)`
`url('data:image/svg+xml,<svg viewbox="0 0 100 100">...</svg>')`
`url(   '   data:image/svg+xml,<svg viewbox="0 0 100 100">...</svg>   '   )`
None of these should be passed to rework-plugin-url, or they will end up with their quotes missing and thus be invalid, as below:
`url('data:image/svg+xml,<svg viewbox=0 0 100 100>...</svg>')`
